### PR TITLE
Check if editor, is the active one

### DIFF
--- a/lib/double-brackets-with-spaces.js
+++ b/lib/double-brackets-with-spaces.js
@@ -26,7 +26,8 @@ export default {
       const buffer = editor.getBuffer();
       const config = atom.config.get('double-brackets-with-spaces');
       const didChangeDisposable = buffer.onDidStopChanging(event => {
-        if (event.changes.length) {
+        const activeEditor = atom.workspace.getActiveTextEditor();
+        if (event.changes.length && activeEditor.id === editor.id) {
           event.changes.map(change => {
             if (config.paste !== 'disabled' || config.paste === 'disabled'  && change.newText !== atom.clipboard.read()) {
               change.newText.split('\n').map((text, index) => {


### PR DESCRIPTION
When there's a change check if the editor is the active one, so we can apply the changes only to the active editor.